### PR TITLE
fix: tag is v1.1.1 not 1.1.1

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -4,6 +4,6 @@
     "renovate_depname": "FiloSottile/age",
     "renovate_versioning": "semver",
     "sha256": "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c",
-    "version": "1.1.1"
+    "version": "v1.1.1"
   }
 }


### PR DESCRIPTION
tag is v1.1.1 not 1.1.1

https://developer.mend.io/github/chickenandpork/experiment-renovate-gh-release-attachments/-/job/08399b8a-8267-483d-8bd4-131172cc4e03 showed:

```
DEBUG: getDigest
{
  "repo": "FiloSottile/age"
  "currentValue": "1.1.1"
  "currentDigest": "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c"
  "registryUrl": "https://github.com"
  "newValue": "1.1.1"
}

DEBUG: GET https://api.github.com/repos/FiloSottile/age/releases/tags/1.1.1 = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=74)
ERROR: lookupUpdates error
```

* curl -Lv https://api.github.com/repos/FiloSottile/age/releases/tags/1.1.1` fails, but 
* curl -Lv https://api.github.com/repos/FiloSottile/age/releases/tags/v1.1.1` succeeds