### PR TITLE
ci: backstep the release to cause renovateBot to suggest an update

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -3,7 +3,7 @@
     "renovate_datasource": "github-release-attachments",
     "renovate_depname": "FiloSottile/age",
     "renovate_versioning": "semver",
-    "sha256": "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c",
-    "version": "v1.1.1"
+    "sha256": "c937585efef8fe4f1fcb6d9eb658ec44c62a43bdfbd1300bf4e0958b4c3f8fa3",
+    "version": "v1.1.0"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # experiment-renovate-gh-release-attachments
 Experimentation in how RenovateBot manages DRY version info for us via github-release-attachments
+
+## RenovateBot
+
+Mend Dashboard for this repo is at https://developer.mend.io/github/chickenandpork/experiment-renovate-gh-release-attachments
+


### PR DESCRIPTION
In order to cause renovateBot to suggest an update, we rollback one minor version for the attachment.

SHA256 generated per:
```
$ shasum -a 256 v-1.1.1.tgz 
81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c  v-1.1.1.tgz

$ shasum -a 256 v-1.1.0.tgz 
c937585efef8fe4f1fcb6d9eb658ec44c62a43bdfbd1300bf4e0958b4c3f8fa3  v-1.1.0.tgz
```

Therefore the sha256 is replaced from `81...7c` to `c9...a3`