### PR TITLE
ci: add another backstepped release -- renovateBot to update different attachment

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -5,5 +5,12 @@
     "renovate_versioning": "semver",
     "sha256": "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c",
     "version": "v1.1.1"
+  },
+  "age_darwin_arm64": {
+    "renovate_datasource": "github-release-attachments",
+    "renovate_depname": "FiloSottile/age",
+    "renovate_versioning": "semver",
+    "sha256": "bd2f57b0391ac0aaebfa742c4320fec58596cd3dc35180c4f9631f57b7588120",
+    "version": "v1.1.0"
   }
 }


### PR DESCRIPTION
This PR expands #5 fixing #4 to a second attachment, different only by sha256.